### PR TITLE
fix: ignore bin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ go.work.sum
 
 # env file
 .env
+bin/


### PR DESCRIPTION
bin directories shouldn't be included in your git repo